### PR TITLE
ansible-playbook --check fails due to skipped register step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   shell: "unbound -h | grep -E '^Version[[:space:]]+[[:digit:].]+$' | cut -f 2 -d' '"
   register: register_unbound_version
   changed_when: false
-  always_run: yes
+  check_mode: no
 
 - set_fact:
     # unbound_version is available for use from this point. note that this

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   shell: "unbound -h | grep -E '^Version[[:space:]]+[[:digit:].]+$' | cut -f 2 -d' '"
   register: register_unbound_version
   changed_when: false
+  always_run: yes
 
 - set_fact:
     # unbound_version is available for use from this point. note that this


### PR DESCRIPTION
`unbound -h` command is not destructive, so it is ok to run it always

fixes #21