### PR TITLE
Adding support for Unbound 1.6

### DIFF
--- a/files/ansible-unbound-checkconf.sh
+++ b/files/ansible-unbound-checkconf.sh
@@ -26,6 +26,7 @@ config_file_to_validate="${1}"
 version=`unbound-checkconf -h | grep -e '^Version' | cut -f 2 -d ' ' | cut -f 1,2 -d '.'`
 
 case "${version}" in
+    1.6)    option="-f -o directory" ;;
     1.5)    option="-f -o directory" ;;
     1.4)    option="-o directory" ;;
     *)      echo "unknown unbound version ${version}" >2


### PR DESCRIPTION
Using this on OpenBSD 6.1, getting hit with:
`"msg": "failed to validate",`

This is what comes by default with OpenBSD in 6.1 according to their [changelog](https://www.openbsd.org/61.html).