### PR TITLE
[bugfix] introduce unbound_include_role_x509_certificate

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -86,3 +86,16 @@ suites:
       - freebsd-10.3-amd64
       - openbsd-6.0-amd64
       - openbsd-6.1-amd64
+
+  - name: x509
+    provisioner:
+      name: ansible_playbook
+      playbook: tests/serverspec/x509.yml
+    verifier:
+      name: shell
+      command: rspec -c -f d -I tests/serverspec tests/serverspec/x509_spec.rb
+    includes:
+      # this test is intended to be a test that ensures the role includes
+      # `x509-certificate` when told so, which is specific to the role, nbot
+      # platforms. thus, testing on a signle platform is sufficient.
+      - freebsd-10.3-amd64

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -96,6 +96,6 @@ suites:
       command: rspec -c -f d -I tests/serverspec tests/serverspec/x509_spec.rb
     includes:
       # this test is intended to be a test that ensures the role includes
-      # `x509-certificate` when told so, which is specific to the role, nbot
+      # `x509-certificate` when told so, which is specific to the role, not
       # platforms. thus, testing on a signle platform is sufficient.
       - freebsd-10.3-amd64

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ unbound. Supported platform includes:
 * OpenBSD
 * FreeBSD
 
+The implementation of `unbound_config_chroot` is quite hackish and is subject
+to change.
+
+See `tests/serverspec/chroot.yml` for the details.
+
 # Requirements
 
 None

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ None
 | `unbound_flags_default` | dict of default variables and their values in startup scripts | `{{ __unbound_flags_default }}` |
 | `unbound_script_dir` | directory to install scripts in `files` | `{{ __unbound_script_dir }}` |
 | `unbound_directory` | work directory of `unbound` | `{{ __unbound_directory }}` |
+| `unbound_include_role_x509_certificate` | include and execute `reallyenglish.x509-certificate` when true | `no` |
 | `unbound_config_chroot` | path to `chroo(2)` directory | `""` |
 | `unbound_freebsd_chroot_devfs_ruleset_number` | `devfs(8)` rule set number. Change when `unbound_config_chroot` is not empty and you have other `devfs(8)` rule set with the same number. | `100` |
 | `unbound_config_server` | list of settings in `server` section (see below) | `[]` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ unbound_flags_default: "{{ __unbound_flags_default }}"
 unbound_script_dir: "{{ __unbound_script_dir }}"
 
 unbound_directory: "{{ __unbound_directory }}"
+unbound_include_role_x509_certificate: no
 unbound_config_chroot: ""
 unbound_freebsd_chroot_devfs_ruleset_number: 100
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,3 @@ galaxy_info:
   galaxy_tags:
     - DNS
     - unbound
-dependencies:
-  - role: reallyenglish.devfsrules
-    when: ansible_os_family == 'FreeBSD' and unbound_config_chroot is defined and unbound_config_chroot | length > 0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,1 +1,2 @@
 - name: reallyenglish.devfsrules
+- name: reallyenglish.x509-certificate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,10 @@
 
 - include: "install-{{ ansible_os_family }}.yml"
 
+- include: "x509.yml"
+  when:
+    - unbound_include_role_x509_certificate
+
 - include: "configure-{{ ansible_os_family }}.yml"
 
 - name: Register unbound version

--- a/tasks/x509.yml
+++ b/tasks/x509.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Include x509-certificate
+  include_role:
+    name: reallyenglish.x509-certificate

--- a/tests/serverspec/chroot.yml
+++ b/tests/serverspec/chroot.yml
@@ -1,6 +1,11 @@
 - hosts: localhost
   roles:
-    - ansible-role-unbound
+    - name: ansible-role-unbound
+    - name: reallyenglish.devfsrules
+      when:
+        - ansible_os_family == 'FreeBSD'
+        - unbound_config_chroot is defined
+        - unbound_config_chroot | length > 0
   vars:
     chroot_dir: "{% if ansible_os_family == 'OpenBSD' %}/var/unbound{% elif ansible_os_family == 'FreeBSD' %}/usr/local/etc/unbound{% endif %}"
 

--- a/tests/serverspec/chroot.yml
+++ b/tests/serverspec/chroot.yml
@@ -4,8 +4,6 @@
     - name: reallyenglish.devfsrules
       when:
         - ansible_os_family == 'FreeBSD'
-        - unbound_config_chroot is defined
-        - unbound_config_chroot | length > 0
   vars:
     chroot_dir: "{% if ansible_os_family == 'OpenBSD' %}/var/unbound{% elif ansible_os_family == 'FreeBSD' %}/usr/local/etc/unbound{% endif %}"
 

--- a/tests/serverspec/x509.yml
+++ b/tests/serverspec/x509.yml
@@ -1,0 +1,141 @@
+- hosts: localhost
+  roles:
+    - ansible-role-unbound
+  vars:
+    debian_flags:
+      DAEMON_OPTS: "-v -c {{ unbound_conf_file }}"
+    freebsd_flags:
+      unbound_flags: "-v -c {{ unbound_conf_file }}"
+    redhat_flags:
+      UNBOUND_OPTIONS: "-v -c {{ unbound_conf_file }}"
+    openbsd_flags:
+      flags: "-v -c {{ unbound_conf_file }}"
+
+    unbound_flags: "{% if ansible_os_family == 'Debian' %}{{ debian_flags }}{% elif ansible_os_family == 'FreeBSD' %}{{ freebsd_flags }}{% elif ansible_os_family == 'RedHat' %}{{ redhat_flags }}{% elif ansible_os_family == 'OpenBSD' %}{{ openbsd_flags }}{% endif %}"
+
+    x509_certificate:
+      - name: unbound
+        state: present
+        public:
+          path: "{{ unbound_conf_dir }}/certs/unbound.pem"
+          owner: "{{ unbound_user }}"
+          group: "{{ unbound_group }}"
+          key: |
+            -----BEGIN CERTIFICATE-----
+            MIIDOjCCAiICCQDaGChPypIR9jANBgkqhkiG9w0BAQUFADBfMQswCQYDVQQGEwJB
+            VTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0
+            cyBQdHkgTHRkMRgwFgYDVQQDDA9mb28uZXhhbXBsZS5vcmcwHhcNMTcwNzE4MDUx
+            OTAxWhcNMTcwODE3MDUxOTAxWjBfMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29t
+            ZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRgwFgYD
+            VQQDDA9mb28uZXhhbXBsZS5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+            AoIBAQDZ9nd1isoGGeH4OFbQ6mpzlldo428LqEYSH4G7fhzLMKdYsIqkMRVl1J3s
+            lXtsMQUUP3dcpnwFwKGzUvuImLHx8McycJKwOp96+5XD4QAoTKtbl59ZRFb3zIjk
+            Owd94Wp1lWvptz+vFTZ1Hr+pEYZUFBkrvGtV9BoGRn87OrX/3JI9eThEpksr6bFz
+            QvcGPrGXWShDJV/hTkWxwRicMMVZVSG6niPusYz2wucSsitPXIrqXPEBKL1J8Ipl
+            8dirQLsH02ZZKcxGctEjlVgnpt6EI+VL6fs5P6A45oJqWmfym+uKztXBXCx+aP7b
+            YUHwn+HV4qzZQld80PSTk6SS3hMXAgMBAAEwDQYJKoZIhvcNAQEFBQADggEBAKgf
+            x3K9GHDK99vsWN8Ej10kwhMlBWBGuM0wkhY0fbxJ0gW3sflK8z42xMc2dhizoYsY
+            sLfN0aylpN/omocl+XcYugLHnW2q8QdsavWYKXqUN0neIMr/V6d1zXqxbn/VKdGr
+            CD4rJwewBattCIL4+S2z+PKr9oCrxjN4i3nujPhKv/yijhrtV+USw1VwuFqsYaqx
+            iScC13F0nGIJiUVs9bbBwBKn1c6GWUHHiFCZY9VJ15SzilWAY/TULsRsHR53L+FY
+            mGfQZBL1nwloDMJcgBFKKbG01tdmrpTTP3dTNL4u25+Ns4nrnorc9+Y/wtPYZ9fs
+            7IVZsbStnhJrawX31DQ=
+            -----END CERTIFICATE-----
+        secret:
+          path: "{{ unbound_conf_dir }}/certs/unbound.key"
+          owner: "{{ unbound_user }}"
+          group: "{{ unbound_group }}"
+          key: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEowIBAAKCAQEA2fZ3dYrKBhnh+DhW0Opqc5ZXaONvC6hGEh+Bu34cyzCnWLCK
+            pDEVZdSd7JV7bDEFFD93XKZ8BcChs1L7iJix8fDHMnCSsDqfevuVw+EAKEyrW5ef
+            WURW98yI5DsHfeFqdZVr6bc/rxU2dR6/qRGGVBQZK7xrVfQaBkZ/Ozq1/9ySPXk4
+            RKZLK+mxc0L3Bj6xl1koQyVf4U5FscEYnDDFWVUhup4j7rGM9sLnErIrT1yK6lzx
+            ASi9SfCKZfHYq0C7B9NmWSnMRnLRI5VYJ6behCPlS+n7OT+gOOaCalpn8pvris7V
+            wVwsfmj+22FB8J/h1eKs2UJXfND0k5Okkt4TFwIDAQABAoIBAHmXVOztj+X3amfe
+            hg/ltZzlsb2BouEN7okNqoG9yLJRYgnH8o/GEfnMsozYlxG0BvFUtnGpLmbHH226
+            TTfWdu5RM86fnjVRfsZMsy+ixUO2AaIG444Y4as7HuKzS2qd5ZXS1XB8GbrCSq7r
+            iF/4tscQrzoG0poQorP9f9y60+z3R45OX3QMVZxP4ZzxXAulHGnECERjLHM5QzTX
+            ALV9PHkTRNd1tm9FSJWWGNO5j4CGxFsPL1kdMyvrC7TkYiIiCQ/dd2CIfQyWwyKc
+            8cHBKnzon0ugr0xlf2B0C7RTXrGAcuBC0yyaLuQTFkocUofgDIFghItH8O8xvvAG
+            j8HYOwECgYEA9uMLtm2C8SiWFuafrF/pPWvhkBtEHA2g22M29CANrVv1jCEVMti/
+            7r53fd328/nVxtashnSFz7a3l3s9d9pTR/rk/rNpVS2i7JGvCXXE3DeoD6Zf4utD
+            MLEs2bI0KabdamIywc77CkVj9WUKd53tlcdcn7AsHwESU4Zjk08ie0kCgYEA4gIa
+            R+a9jmKEk9l5Gn7jroxDJdI0gEfuA7It5hshEDcSvjF+Fs5+1tVgfBI1Mx4/0Eaj
+            6E57Ln3WFKPJKuG0HwLNanZcqLFgiC/7ANbyKxfONPVrqC2TClImBhkQ74BLafZg
+            yY8/N/g/5RIMpYvQ9snBRsah9G2cBfuPTHjku18CgYBHylPQk12dJJEoTZ2msSkQ
+            jDtF/Te79JaO1PXY3S08+N2ZBtG0PGTrVoVGm3HBFif8rtXyLxXuBZKzQMnp/Rl0
+            d9d43NDHTQLwSZidZpp88s4y5s1BHeom0Y5aK0CR0AzYb3+U7cv/+5eKdvwpNkos
+            4JDleoQJ6/TZRt3TqxI6yQKBgA8sdPc+1psooh4LC8Zrnn2pjRiM9FloeuJkpBA+
+            4glkqS17xSti0cE6si+iSVAVR9OD6p0+J6cHa8gW9vqaDK3IUmJDcBUjU4fRMNjt
+            lXSvNHj5wTCZXrXirgraw/hQdL+4eucNZwEq+Z83hwHWUUFAammGDHmMol0Edqp7
+            s1+hAoGBAKCGZpDqBHZ0gGLresidH5resn2DOvbnW1l6b3wgSDQnY8HZtTfAC9jH
+            DZERGGX2hN9r7xahxZwnIguKQzBr6CTYBSWGvGYCHJKSLKn9Yb6OAJEN1epmXdlx
+            kPF7nY8Cs8V8LYiuuDp9UMLRc90AmF87rqUrY5YP2zw6iNNvUBKs
+            -----END RSA PRIVATE KEY-----
+    unbound_include_role_x509_certificate: yes
+    unbound_config_chroot: ""
+    unbound_config_server:
+      - name: ssl-port
+        value: 853
+      - name: ssl-service-pem
+        value: "{{ unbound_conf_dir }}/certs/unbound.pem"
+      - name: ssl-service-key
+        value: "{{ unbound_conf_dir }}/certs/unbound.key"
+      - name: interface
+        values:
+          - 127.0.0.1
+          - 127.0.0.1@853
+          - "{{ ansible_default_ipv4.address }}"
+      - "outgoing-interface: {{ ansible_default_ipv4.address }}"
+      - "do-not-query-localhost: yes"
+      - "do-ip4: yes"
+      - "do-ip6: no"
+      - "hide-identity: yes"
+      - "hide-version: yes"
+      # you may use dict, too
+      - name: use-syslog
+        value: "yes"
+      # some settings are allowed to appear multiple times, which makes
+      # `unbound.conf(5)` different from YAML.
+      - name: local-zone
+        values:
+          - 10.in-addr.arpa nodefault
+          - 168.192.in-addr.arpa nodefault
+      - name: access-control
+        values:
+          - 0.0.0.0/0 refuse
+          - 127.0.0.0/8 allow
+          - 10.100.1.0/24 allow
+      - name: private-address
+        values:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+          - 192.254.0.0/16
+          - fc00::/7
+          - fd00::/8
+          - fe80::/10
+      - name: private-domain
+        values:
+          - '"example.com"'
+    # unbound in ubuntu 14.04 does not support unix socket
+    unbound_config_remote_control_control_interface: "{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('14.04', '<=')) or (ansible_distribution == 'CentOS' and ansible_distribution_version | version_compare('7.3.1611', '<=')) %}127.0.0.1{% else %}/var/run/unbound.sock{% endif %}"
+    unbound_forward_zone:
+      -
+        name: example.com
+        forward-addr:
+          - 8.8.8.8
+          - 8.8.4.4
+      -
+        name: example.org
+        forward-addr:
+          - 8.8.8.8
+    unbound_stub_zone:
+      - name: example.net
+        stub-addr:
+          - 8.8.8.8
+          - 8.8.4.4
+      - name: foo.example
+        stub-addr:
+          - 8.8.8.8

--- a/tests/serverspec/x509_spec.rb
+++ b/tests/serverspec/x509_spec.rb
@@ -1,0 +1,11 @@
+require_relative "default_spec.rb"
+
+describe port(853) do
+  it { should be_listening }
+end
+
+describe command("echo | openssl s_client -connect 127.0.0.1:853 -showcerts") do
+  its(:stdout) { should match(/#{Regexp.escape("issuer=/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=foo.example.org")}/) }
+  its(:stderr) { should match(/verify error:num=18:self signed certificate/) }
+  its(:exit_status) { should eq 0 }
+end

--- a/tests/serverspec/x509_spec.rb
+++ b/tests/serverspec/x509_spec.rb
@@ -1,10 +1,11 @@
 require_relative "default_spec.rb"
 
-describe port(853) do
+tls_port = 853
+describe port(tls_port) do
   it { should be_listening }
 end
 
-describe command("echo | openssl s_client -connect 127.0.0.1:853 -showcerts") do
+describe command("echo | openssl s_client -connect 127.0.0.1:#{tls_port} -showcerts") do
   its(:stdout) { should match(/#{Regexp.escape("issuer=/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=foo.example.org")}/) }
   its(:stderr) { should match(/verify error:num=18:self signed certificate/) }
   its(:exit_status) { should eq 0 }


### PR DESCRIPTION
fixes #41

also:

* state `chroot` support is hackish. the more I look at it, the more I
  hate it
* remove hard-dependency from `meta/main.yml`. it is soft only required
  when specific conditions are true